### PR TITLE
Add path exception

### DIFF
--- a/src/Http/Middleware/TmdBSA.php
+++ b/src/Http/Middleware/TmdBSA.php
@@ -19,7 +19,8 @@ class TmdBSA
     {
         if (!empty($providers)) {
             foreach ($providers as $provider) {
-                throw_if(! in_array($provider, array_keys(config('tmd-bsa'))),
+                throw_if(
+                    !in_array($provider, array_keys(config('tmd-bsa'))),
                     InvalidProviderException::class,
                     'Unregistered provider.'
                 );
@@ -41,6 +42,18 @@ class TmdBSA
     {
         if (config('tmd-bsa.env_local_only') && config('app.env') == 'production')
             return;
+
+        if (config('tmd-bsa.except')) {
+            foreach (config('tmd-bsa.except') as $except) {
+                if ($except !== '/') {
+                    $except = trim($except, '/');
+                }
+
+                if ($request->fullUrlIs($except) || $request->is($except)) {
+                    return;
+                }
+            }
+        }
 
         if ($request->getUser() !== $credential['username'] || $request->getPassword() !== $credential['password']) {
             $headers = ['WWW-Authenticate' => 'Basic'];

--- a/src/config/tmd-basic-auth.php
+++ b/src/config/tmd-basic-auth.php
@@ -6,6 +6,9 @@ return [
         'username' => env('TMD_BSA_USERNAME', 'admin'),
         'password' => env('TMD_BSA_PASSWORD', 'admin'),
     ],
+    'except' => [
+        // 'midtrans-notify'
+    ]
     // 'admin' => [
     //     'username' => 'newusername',
     //     'password' => 'newpassword',


### PR DESCRIPTION
In the development environment, there are situations where we need certain paths to be exempted from authentication checks. For instance, webhook endpoints for payment gateways like Midtrans or other scenarios.